### PR TITLE
Fix: 부스 상세페이지 캐러셀 위치 수정, 운영일시 표시 방법 수정

### DIFF
--- a/src/components/Booth/BoothCards.tsx
+++ b/src/components/Booth/BoothCards.tsx
@@ -159,7 +159,7 @@ export default function BoothCards({
     const formattedStartTime = formatTime(start_time);
     const formattedEndTime = formatTime(end_time);
     if (startDay !== endDay) {
-      return `${startDay}일, ${endDay}일, ${formattedStartTime} ~ ${formattedEndTime}`;
+      return `${startDay}일 ~ ${endDay}일, ${formattedStartTime} ~ ${formattedEndTime}`;
     }
     return `${startDay}일, ${formattedStartTime} ~ ${formattedEndTime}`;
   };

--- a/src/pages/Booth/BoothDetails.tsx
+++ b/src/pages/Booth/BoothDetails.tsx
@@ -116,7 +116,7 @@ export default function BoothDetail() {
     const formattedStartTime = formatTime(start_time);
     const formattedEndTime = formatTime(end_time);
     if (startDay !== endDay) {
-      return `${startDay}일, ${endDay}일, ${formattedStartTime} ~ ${formattedEndTime}`;
+      return `${startDay}일 ~ ${endDay}일, ${formattedStartTime} ~ ${formattedEndTime}`;
     }
     return `${startDay}일, ${formattedStartTime} ~ ${formattedEndTime}`;
   };
@@ -126,7 +126,7 @@ export default function BoothDetail() {
       <h1 className="mb-10 text-main text-4xl font-cafe24">부스</h1>
       <div className="flex flex-col w-full max-w-[90%] flex-grow">
         {/* 부스 정보 및 내용 */}
-        <div className="w-full max-w-[90%] text-center">
+        <div className="w-full text-center">
           <BoothCarousel images={boothData?.images} />
         </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #34 

## 📝작업 내용

> 부스 상세페이지 캐러셀 위치 수정, 운영일시 표시 방법 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
